### PR TITLE
add home button

### DIFF
--- a/src/window.blp
+++ b/src/window.blp
@@ -125,14 +125,6 @@ template $SudokuWindow: Adw.ApplicationWindow {
 menu main_menu {
   section {
     item {
-      label: _("_Back to Main Menu");
-      action: "win.back-to-menu";
-      tooltip-text: _("Back to main menu");
-    }
-  }
-
-  section {
-    item {
       label: _("_Keyboard Shortcuts");
       action: "win.show-help-overlay";
       tooltip-text: _("Keyboard shortcuts");


### PR DESCRIPTION
was issued in https://github.com/sepehr-rs/Sudoku/issues/110

it's a duplicate button as `win.back-to-menu` action, works same.

<img width="850" height="738" alt="image" src="https://github.com/user-attachments/assets/2ae77ecc-910f-44da-aacb-68e89969a57b" />
<img width="850" height="738" alt="image" src="https://github.com/user-attachments/assets/520fba51-6b55-4467-8a6a-b4ad77cc42b2" />
