### PR TITLE
Fix CSS warning due to missing semicolon

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -45,7 +45,7 @@ statuspage image {
 }
 
 #sudoku-parent-grid button.entry-cell.wrong {
-    background-color: rgba(206, 106, 64, 0.50)
+    background-color: rgba(206, 106, 64, 0.50);
 }
 
 #sudoku-parent-grid button.entry-cell.correct.highlight {


### PR DESCRIPTION
Removes the following warnings seen at startup:

```
(sudokugame:2): Gtk-WARNING **: 15:22:15.783: Theme parser warning: style.css:48:5-49:1: Expected ';' at end of block

(sudokugame:2): Gtk-WARNING **: 15:22:15.783: Theme parser warning: style.css:48:5-49:1: Expected ';' at end of block
Application exited
```