### PR TITLE
Rework Difficulty Selection Dialog

### DIFF
--- a/src/difficulty_selection_dialog.py
+++ b/src/difficulty_selection_dialog.py
@@ -1,0 +1,79 @@
+# difficulty_selection_dialog.py
+#
+# Copyright 2025 sepehr-rs, Alexander Vanhee
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from gi.repository import Gtk, Adw
+
+from functools import partial
+from gettext import gettext as _
+
+from .game_board import (
+    EASY_DIFFICULTY,
+    MEDIUM_DIFFICULTY,
+    HARD_DIFFICULTY,
+    EXTREME_DIFFICULTY,
+)
+
+
+class DifficultySelectionDialog(Adw.Dialog):
+    def __init__(self, on_select, **kwargs):
+        super().__init__()
+        self.set_title(_("Select Difficulty"))
+        self.set_content_width(250)
+        self.set_content_height(290)
+
+        toolbar_view = Adw.ToolbarView.new()
+        header = Adw.HeaderBar()
+        toolbar_view.add_top_bar(header)
+
+        box = Gtk.ListBox(margin_start=12, margin_end=12, margin_top=12)
+        box.add_css_class("boxed-list-separate")
+        toolbar_view.set_content(box)
+
+        # Create difficulty buttons
+        difficulties = [
+            ("Easy", EASY_DIFFICULTY),
+            ("Medium", MEDIUM_DIFFICULTY),
+            ("Hard", HARD_DIFFICULTY),
+            ("Extreme", EXTREME_DIFFICULTY),
+        ]
+
+        for label_text, difficulty_value in difficulties:
+            button = Adw.ButtonRow(title=label_text)
+            button.add_css_class("text-button")
+            button.set_tooltip_text(
+                _(
+                    "Start new game with {} difficulty"
+                ).format(label_text.lower())
+            )
+            button.connect(
+                "activated",
+                partial(
+                    self._on_button_clicked,
+                    on_select,
+                    difficulty_value,
+                    label_text
+                ),
+            )
+            box.append(button)
+
+        self.set_child(toolbar_view)
+
+    def _on_button_clicked(self, callback, difficulty, label, *args):
+        callback(difficulty, label)
+        self.close()

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,6 +51,7 @@ sudoku_sources = [
   'game_manager.py',
   'sudoku_cell.py',
   'help_dialog.py',
+  'difficulty_selection_dialog.py',
   'ui_helpers.py',
   'finished_overlay.py',
 ]

--- a/src/window.py
+++ b/src/window.py
@@ -18,18 +18,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gi.repository import Adw, Gtk, Gio
-from functools import partial
 from gettext import gettext as _
 
-from .game_board import (
-    GameBoard,
-    EASY_DIFFICULTY,
-    MEDIUM_DIFFICULTY,
-    HARD_DIFFICULTY,
-    EXTREME_DIFFICULTY,
-)
+from .game_board import GameBoard
 from .game_manager import GameManager
 from .ui_helpers import UIHelpers
+from .difficulty_selection_dialog import DifficultySelectionDialog
 
 
 @Gtk.Template(resource_path="/io/github/sepehr_rs/Sudoku/window.ui")
@@ -128,49 +122,12 @@ class SudokuWindow(Adw.ApplicationWindow):
         self._show_difficulty_dialog()
 
     def _show_difficulty_dialog(self):
-        """Show the difficulty selection dialog."""
-        dialog = Gtk.Dialog(
-            title="Select Difficulty",
-            transient_for=self,
-            modal=True,
+        dialog = DifficultySelectionDialog(
+            on_select=self.on_difficulty_selected
         )
+        dialog.present(self)
 
-        box = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL,
-            spacing=12,
-            margin_top=24,
-            margin_bottom=24,
-            margin_start=24,
-            margin_end=24,
-        )
-        dialog.get_content_area().append(box)
-        dialog.get_style_context().add_class("sudoku-dialog")
-
-        # Create difficulty buttons
-        difficulties = [
-            ("Easy", EASY_DIFFICULTY),
-            ("Medium", MEDIUM_DIFFICULTY),
-            ("Hard", HARD_DIFFICULTY),
-            ("Extreme", EXTREME_DIFFICULTY),
-        ]
-
-        for difficulty_label, difficulty in difficulties:
-            button = Gtk.Button(label=difficulty_label)
-            button.set_tooltip_text(
-                _("Start new game with {} difficulty").format(difficulty_label.lower())
-            )
-            button.connect(
-                "clicked",
-                partial(self.on_difficulty_selected, difficulty, difficulty_label),
-            )
-            box.append(button)
-
-        dialog.show()
-
-    def on_difficulty_selected(
-        self, difficulty: float, difficulty_label: str, button: Gtk.Button
-    ):
+    def on_difficulty_selected(self, difficulty: float, difficulty_label: str):
         """Handle difficulty selection."""
         self.sudoku_window_title.set_subtitle(f"{difficulty_label}")
         self.game_manager.start_game(difficulty, difficulty_label)
-        button.get_root().destroy()


### PR DESCRIPTION
This PR moves the dialog out of the `window.py` file for better maintainability, 
switches to `Adw.Dialog`, and uses `Adw.ButtonRow` for larger buttons, 
which are commonly used in these types of popups.

<img width="850" height="650" alt="Screenshot From 2025-08-18 16-43-56" src="https://github.com/user-attachments/assets/829cafa9-c2b7-4e3a-bffa-86e89778405e" />
