### PR TITLE
switch to AboutDialog

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -22,7 +22,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Gio, Adw
+from gi.repository import Gio, Adw, Gtk
 from .window import SudokuWindow
 from .help_dialog import HowToPlayDialog
 
@@ -62,16 +62,16 @@ class SudokuApplication(Adw.Application):
 
     def on_about_action(self, widget, _):
         """Callback for the app.about action."""
-        about = Adw.AboutWindow(
-            transient_for=self.props.active_window,
+        about = Adw.AboutDialog(
             application_name="Sudoku",
             application_icon="io.github.sepehr_rs.Sudoku",
             developer_name="Sepehr",
             version=self.version,
             developers=["Sepehr", "Revisto"],
             copyright="© 2025 sepehr-rs",
+            license_type=Gtk.License.GPL_3_0,
         )
-        about.present()
+        about.present(self.props.active_window)
 
     def on_how_to_play(self, action, param):
         """Show how to play dialog."""


### PR DESCRIPTION
`AboutWindow` has been **deprecated** since Adwaita 1.6.  
See: [AboutWindow documentation](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.6/class.AboutWindow.html).

Additionally, I took the liberty of adding the license info.
