### PR TITLE
Add transition between the main views

### DIFF
--- a/src/window.blp
+++ b/src/window.blp
@@ -7,10 +7,10 @@ template $SudokuWindow: Adw.ApplicationWindow {
   ]
 
   title: _("Sudoku");
-  default-width: 800;
-  default-height: 600;
-  width-request: 360;
-  height-request: 420;
+  default-width: 750;
+  default-height: 750;
+  width-request: 725;
+  height-request: 725;
 
 
   content: Adw.ToolbarView {
@@ -44,7 +44,10 @@ template $SudokuWindow: Adw.ApplicationWindow {
       }
     }
 
-    content: Adw.ViewStack stack {
+    content: Stack stack {
+      transition-type:crossfade;
+      transition-duration: 300;
+
       ScrolledWindow main_menu_box {
         hscrollbar-policy: never;
 


### PR DESCRIPTION
Changed `ViewStack` to `Stack`, as the former does not actually provide a transition without using `ViewSwitcher`.
See [documentation](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.5/class.ViewStack.html).

I also temporarily changed the minimum dimensions of the window because the main game view does not yet support smaller sizes, and the jump between them was jarring. This will have to change when #75 gets implemented

Closes #46
