### PR TITLE
Add jumping between blocks via ctrl+arrow keys

### DIFF
--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -263,8 +263,13 @@ class GameManager:
             Gdk.KEY_Right: (0, -1 if is_rtl else 1),
         }
 
+        ctrl_pressed = state & Gdk.ModifierType.CONTROL_MASK
+
         if keyval in directions:
             d_row, d_col = directions[keyval]
+            if ctrl_pressed:
+                d_row *= 3
+                d_col *= 3
             new_row, new_col = row + d_row, col + d_col
             if 0 <= new_row < 9 and 0 <= new_col < 9:
                 self._focus_cell(new_row, new_col)

--- a/src/gtk/help-overlay.blp
+++ b/src/gtk/help-overlay.blp
@@ -5,7 +5,6 @@ ShortcutsWindow help_overlay {
 
   ShortcutsSection {
     section-name: "shortcuts";
-    max-height: 10;
 
     ShortcutsGroup {
       title: C_("shortcut window", "Game");
@@ -13,6 +12,19 @@ ShortcutsWindow help_overlay {
       ShortcutsShortcut {
         title: C_("shortcut window", "Pencil Mode");
         action-name: "win.pencil-toggled";
+      }
+
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Move between cells");
+        accelerator: "Up Down Left Right";
+      }
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Jump between blocks");
+        accelerator: "<Primary>Up Down Left Right";
+      }
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Open number pop-up");
+        accelerator: "Return";
       }
     }
 
@@ -27,6 +39,11 @@ ShortcutsWindow help_overlay {
       ShortcutsShortcut {
         title: C_("shortcut window", "Back to Main Menu");
         action-name: "win.back-to-menu";
+      }
+
+      ShortcutsShortcut {
+        title: C_("shortcut window", "How to play");
+        action-name: "app.how_to_play";
       }
 
       ShortcutsShortcut {


### PR DESCRIPTION
Jumping between blocks should preserve the position within a block. If there is no block in that direction, movement will proceed normally, as if Ctrl were not pressed.

Also adds some missing entries to the keyboard shortcuts page.

Closes #117

