### PR TITLE
Change gnome runtime version to 48

### DIFF
--- a/io.github.sepehr_rs.Sudoku.Devel.json
+++ b/io.github.sepehr_rs.Sudoku.Devel.json
@@ -1,7 +1,7 @@
 {
     "id" : "io.github.sepehr_rs.Sudoku.Devel",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "master",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "sudokugame",
     "finish-args" : [

--- a/io.github.sepehr_rs.Sudoku.json
+++ b/io.github.sepehr_rs.Sudoku.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.sepehr_rs.Sudoku",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "master",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "sudokugame",
     "finish-args" : [


### PR DESCRIPTION
Fixes the GNOME runtime missing error in GNOME Builder.

<img width="538" height="274" alt="image" src="https://github.com/user-attachments/assets/f92380b9-f550-46fb-bdde-10695d304a08" />

(screenshot of the same issue for drum machine)
