### PR TITLE
feat : filter numbers in _fill_cell function

### DIFF
--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -194,8 +194,7 @@ class GameManager:
     def _fill_cell(self, cell: SudokuCell, number: str, ctrl_is_pressed=False):
         UIHelpers.clear_conflicts(self.conflict_cells)
         row, col = cell.row, cell.col
-        valid_numbers = "123456789"
-        if number in valid_numbers:
+        if number != "0":
             if self.pencil_mode or ctrl_is_pressed:
                 if number in self.game_board.get_notes(row, col):
                     self.game_board.remove_note(row, col, number)


### PR DESCRIPTION
Hello @sepehr-rs 
From now on, we can no longer enter the number zero in Sudoku by entering the number zero on the keyboard, whether with or without pressing the control key. 

In fact, issue number #178  has been resolved.