### PR TITLE
BugFix: Block not touchable after completing #174

### DIFF
--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -279,6 +279,7 @@ class GameManager:
             self._show_popover(cell, gesture.get_current_button())
         else:
             cell.grab_focus()
+        gesture.reset()
 
     def on_key_pressed(self, controller, keyval, keycode, state, row: int, col: int):
         # Left and right gets needs to be swapped in RTL as whole board is flipped


### PR DESCRIPTION
I believe the issue originates from the GTK side. Strangely, when you left-click for the second time, it does not register as a new gesture, even though the event has ended. 

There is a workaround on the player side: you can left-click, then right-click, and then left-click again to interact with the cell. 

The current fix simply resets the gesture, making it as if the previous mouse click never occurred, allowing the new mouse click to be registered.