### PR TITLE
fix(timeout-cleanup): Clean up cell timeout IDs before grid clear

### DIFF
--- a/src/variants/classic_sudoku/manager.py
+++ b/src/variants/classic_sudoku/manager.py
@@ -34,7 +34,6 @@ class ClassicSudokuManager(ManagerBase):
         self.key_map, self.remove_keys = ClassicUIHelpers.setup_key_mappings()
         self.parent_grid = None
         self.blocks = []
-        self._idle_source_id = None
 
     def start_game(self, difficulty: float, difficulty_label: str, variant: str):
         self.window.stack.set_visible_child(self.window.loading_screen)
@@ -42,14 +41,15 @@ class ClassicSudokuManager(ManagerBase):
 
         def worker():
             self.board = ClassicSudokuBoard(difficulty, difficulty_label, variant)
-            if self._idle_source_id:
-                try:
-                    GLib.source_remove(self._idle_source_id)
-                except Exception:
-                    pass
-            self._idle_source_id = GLib.idle_add(self._on_game_ready)
+            GLib.idle_add(self._finish_start_game, self.board)
 
         threading.Thread(target=worker, daemon=True).start()
+
+    def _finish_start_game(self, board):
+        self.board = board
+        self.build_grid()
+        self.window.stack.set_visible_child(self.window.game_scrolled_window)
+        return False
 
     def _on_game_ready(self):
         self._idle_source_id = None
@@ -112,12 +112,7 @@ class ClassicSudokuManager(ManagerBase):
             for row in self.cell_inputs:
                 for cell in row:
                     if cell:
-                        for tid in getattr(cell, "feedback_timeout_ids", []):
-                            try:
-                                GLib.source_remove(tid)
-                            except Exception:
-                                pass
-                        cell.feedback_timeout_ids = []
+                        cell.clear_feedback_timeout()
 
         while child := self.window.grid_container.get_first_child():
             self.window.grid_container.remove(child)
@@ -376,13 +371,7 @@ class ClassicSudokuManager(ManagerBase):
             for row in self.cell_inputs:
                 for cell in row:
                     if cell:
-                        for tid in getattr(cell, "feedback_timeout_ids", []):
-                            try:
-                                GLib.source_remove(tid)
-                            except Exception:
-                                pass
-                        cell.feedback_timeout_ids = []
-
+                        cell.clear_feedback_timeout()
         while child := self.window.grid_container.get_first_child():
             self.window.grid_container.remove(child)
         self.window.stack.set_visible_child(self.window.finished_page)
@@ -409,24 +398,19 @@ class ClassicSudokuManager(ManagerBase):
 
     def _clear_feedback(self, cell):
         """Remove existing highlights, tooltips, and timeouts for a cell."""
-        for tid in getattr(cell, "feedback_timeout_ids", []):
-            GLib.source_remove(tid)
-        cell.feedback_timeout_ids = []
+        cell.clear_feedback_timeout()
         cell.remove_highlight("correct")
         cell.remove_highlight("wrong")
         cell.set_tooltip_text("")
-
-    def _register_timeout(self, cell, callback, delay=3000):
-        """Register a GLib timeout and track it on the cell."""
-        tid = GLib.timeout_add(delay, callback)
-        cell.feedback_timeout_ids.append(tid)
 
     def _handle_correct_input(self, cell):
         """Handle behavior when the user enters the correct number."""
         cell.set_editable(False)
         cell.highlight("correct")
-        cell.set_tooltip_text("Correct")
-        self._register_timeout(cell, lambda: self._clear_correct_feedback(cell))
+        cell.set_tooltip_text("Correct")    
+        cell.start_feedback_timeout(
+            lambda: self._clear_correct_feedback(cell)
+        )
 
     def _clear_correct_feedback(self, cell):
         """Remove correct highlight and tooltip."""
@@ -444,7 +428,8 @@ class ClassicSudokuManager(ManagerBase):
         )
         self.conflict_cells.extend(conflicts)
 
-        self._register_timeout(cell, self._clear_conflicts)
+        cell.start_feedback_timeout(self._clear_conflicts)
+
 
     def _clear_conflicts(self):
         """Clear conflicts highlight after timeout."""


### PR DESCRIPTION
Fix GLib timeout source IDs not being cleaned up when game grid is cleared, causing "[GLib] Source ID X was not found" errors and Flatpak crashes.
This fix ensures all cell timeout IDs are properly removed before grid widgets are destroyed, preventing attempts to remove stale or already-fired source IDs.
Changes:
- Add cleanup loop to `_clear_previous_grid()` to iterate through all cells and cancel pending timeouts
- Add cleanup loop to `_show_puzzle_finished_dialog()` for same behavior
- Use try/except around `GLib.source_remove()` to handle already-fired sources
- Track `idle_add` source ID for proper cancellation
