### PR TITLE
fix: swap arrow key directions in RTL layouts

### DIFF
--- a/src/screens/help_dialog.py
+++ b/src/screens/help_dialog.py
@@ -66,7 +66,14 @@ class HowToPlayDialog(Adw.Dialog):
         return key
 
     def on_key_pressed(self, controller, keyval, keycode, state):
+        is_rtl = self.get_direction() == Gtk.TextDirection.RTL
         if keyval == Gdk.KEY_Right:
-            self.on_next_clicked(self.next)
+            if is_rtl:
+                self.on_prev_clicked(self.prev)
+            else:
+                self.on_next_clicked(self.next)
         elif keyval == Gdk.KEY_Left:
-            self.on_prev_clicked(self.prev)
+            if is_rtl:
+                self.on_next_clicked(self.next)
+            else:
+                self.on_prev_clicked(self.prev)

--- a/src/variants/classic_sudoku/manager.py
+++ b/src/variants/classic_sudoku/manager.py
@@ -291,11 +291,14 @@ class ClassicSudokuManager(ManagerBase):
         return False
 
     def _handle_arrow_keys(self, keyval, ctrl, row, col):
+        direction = self.window.get_direction()
+        is_rtl = direction == Gtk.TextDirection.RTL
+
         directions = {
             Gdk.KEY_Up: (-1, 0),
             Gdk.KEY_Down: (1, 0),
-            Gdk.KEY_Left: (0, -1),
-            Gdk.KEY_Right: (0, 1),
+            Gdk.KEY_Left: (0, -1) if not is_rtl else (0, 1),
+            Gdk.KEY_Right: (0, 1) if not is_rtl else (0, -1),
         }
         if keyval not in directions:
             return False


### PR DESCRIPTION
Restore RTL arrow key handling that was lost during refactoring. When GNOME is set to RTL layout (e.g., Persian), left/right arrow keys are now correctly swapped for both game navigation and help dialog carousel.

Fixes #137